### PR TITLE
Add X-Identity header to API requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,6 +149,7 @@ const updateDb = () => {
 	//get
 	axios.get(config.scamApi, {
 		headers: {
+			'X-Identity': 'github.com/ChrisChrome/ScamBaiter',
 			'User-Agent': 'ScamBaiter/1.0; Chris Chrome#9158'
 			// Mozilla/5.0 (compatible; <botname>/<botversion>; +<boturl>)
 		}


### PR DESCRIPTION
This is being nicely asked for in the [docs](https://phish.sinking.yachts/docs), so it should be included

![Screenshot](https://i.imgur.com/mvh1Nis.png)